### PR TITLE
[ALS-8838] Add datasets to facets table

### DIFF
--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/dataset/DatasetFacetRefreshService.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/dataset/DatasetFacetRefreshService.java
@@ -1,0 +1,59 @@
+package edu.harvard.dbmi.avillach.dictionaryetl.dataset;
+
+import edu.harvard.dbmi.avillach.dictionaryetl.facet.FacetConceptRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.facet.FacetRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.facetcategory.FacetCategoryModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.facetcategory.FacetCategoryRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class DatasetFacetRefreshService {
+    private static final Logger log = LoggerFactory.getLogger(DatasetFacetRefreshService.class);
+    private final DatasetRepository datasetRepository;
+    private final FacetRepository facetRepository;
+    private final FacetCategoryRepository facetCategoryRepository;
+    private final FacetConceptRepository facetConceptRepository;
+
+    @Autowired
+    public DatasetFacetRefreshService(
+        DatasetRepository datasetRepository,
+        FacetRepository facetRepository,
+        FacetCategoryRepository facetCategoryRepository,
+        FacetConceptRepository facetConceptRepository
+    ) {
+        this.datasetRepository = datasetRepository;
+        this.facetRepository = facetRepository;
+        this.facetCategoryRepository = facetCategoryRepository;
+        this.facetConceptRepository = facetConceptRepository;
+    }
+
+    public void refreshDatasetFacet() {
+        if (datasetRepository.findAll().size() < 2) {
+            log.info("Less than 2 datasets detected. Not altering facets");
+            return;
+        }
+
+        Optional<FacetCategoryModel> maybeCategory = facetCategoryRepository.findByName("dataset_id");
+        FacetCategoryModel category;
+        if (maybeCategory.isPresent()) {
+            category = maybeCategory.get();
+            log.info("Found a dataset_id facet category. Deleting all associated facets and facet pairs");
+            facetConceptRepository.deleteAllForCategory(category.getFacetCategoryId());
+            facetRepository.deleteAllForCategory(category.getFacetCategoryId());
+        } else {
+            log.info("Did not find a dataset_id facet category. Creating...");
+            category = new FacetCategoryModel("dataset_id", "Dataset", "The dataset this concept belongs to");
+            facetCategoryRepository.save(category);
+        }
+
+        log.info("Adding facets for each dataset");
+        facetRepository.createFacetForEachDatasetForCategory(category.getFacetCategoryId());
+        log.info("Adding facet/concept pairs for each leaf concept node");
+        facetConceptRepository.createDatasetPairForEachLeafConcept(category.getFacetCategoryId());
+    }
+}

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/facet/FacetRepository.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/facet/FacetRepository.java
@@ -47,4 +47,18 @@ public interface FacetRepository extends JpaRepository<FacetModel, Long> {
         WHERE cn.dataset_id = :datasetID
         """, nativeQuery = true)
     List<ConceptToFacetDTO> findFacetToConceptRelationshipsByDatasetID(@Param("datasetID") Long datasetID);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM dict.facet WHERE facet_category_id = :catId", nativeQuery = true)
+    void deleteAllForCategory(@Param("catId") Long catId);
+
+    @Modifying
+    @Transactional
+    @Query(value = """
+        INSERT INTO dict.facet (FACET_CATEGORY_ID, NAME, DISPLAY, DESCRIPTION)
+        SELECT :catId, REF, REF, COALESCE(FULL_NAME, '')
+        FROM dict.dataset
+        """, nativeQuery = true)
+    void createFacetForEachDatasetForCategory(@Param("catId") Long catId);
 }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/DictionaryLoaderController.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/DictionaryLoaderController.java
@@ -1,6 +1,7 @@
 package edu.harvard.dbmi.avillach.dictionaryetl.loading;
 
 import edu.harvard.dbmi.avillach.dictionaryetl.Utility.DatabaseCleanupUtility;
+import edu.harvard.dbmi.avillach.dictionaryetl.dataset.DatasetFacetRefreshService;
 import edu.harvard.dbmi.avillach.dictionaryetl.facet.FacetService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,12 +24,14 @@ public class DictionaryLoaderController {
     private final FacetService facetService;
     private final DatabaseCleanupUtility databaseCleanupUtility;
     private final ReentrantLock reentrantLock = new ReentrantLock();
+    private final DatasetFacetRefreshService datasetFacetRefreshService;
 
     @Autowired
-    public DictionaryLoaderController(DictionaryLoaderService dictionaryLoaderService, FacetService facetService, DatabaseCleanupUtility databaseCleanupUtility) {
+    public DictionaryLoaderController(DictionaryLoaderService dictionaryLoaderService, FacetService facetService, DatabaseCleanupUtility databaseCleanupUtility, DatasetFacetRefreshService datasetFacetRefreshService) {
         this.dictionaryLoaderService = dictionaryLoaderService;
         this.facetService = facetService;
         this.databaseCleanupUtility = databaseCleanupUtility;
+        this.datasetFacetRefreshService = datasetFacetRefreshService;
     }
 
     /**
@@ -61,6 +64,7 @@ public class DictionaryLoaderController {
                 if (includeDefaultFacets) {
                     this.facetService.createDefaultFacets();
                 }
+                datasetFacetRefreshService.refreshDatasetFacet();
             } finally {
                 reentrantLock.unlock();
             }

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/dataset/DatasetFacetRefreshServiceTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/dataset/DatasetFacetRefreshServiceTest.java
@@ -1,0 +1,125 @@
+package edu.harvard.dbmi.avillach.dictionaryetl.dataset;
+
+import edu.harvard.dbmi.avillach.dictionaryetl.Utility.DatabaseCleanupUtility;
+import edu.harvard.dbmi.avillach.dictionaryetl.concept.ConceptModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.concept.ConceptRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.facet.FacetConceptModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.facet.FacetConceptRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.facet.FacetModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.facet.FacetRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.facetcategory.FacetCategoryModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.facetcategory.FacetCategoryRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Testcontainers
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@SpringBootTest
+class DatasetFacetRefreshServiceTest {
+    @Autowired
+    DatasetFacetRefreshService subject;
+    @Autowired
+    private DatabaseCleanupUtility databaseCleanupUtility;
+
+    @Autowired
+    FacetRepository facetRepository;
+
+    @Autowired
+    FacetCategoryRepository facetCategoryRepository;
+
+    @Autowired
+    ConceptRepository conceptRepository;
+
+    @Autowired
+    DatasetRepository datasetRepository;
+
+    @Autowired
+    FacetConceptRepository facetConceptRepository;
+
+    @Container
+    static final PostgreSQLContainer<?> databaseContainer = new PostgreSQLContainer<>("postgres:16")
+        .withDatabaseName("testdb")
+        .withUsername("testuser")
+        .withPassword("testpass")
+        .withCopyFileToContainer(
+            MountableFile.forClasspathResource("schema.sql"),
+            "/docker-entrypoint-initdb.d/schema.sql"
+        );
+
+    @DynamicPropertySource
+    static void mySQLProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", databaseContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", databaseContainer::getUsername);
+        registry.add("spring.datasource.password", databaseContainer::getPassword);
+    }
+
+    @BeforeEach
+    void cleanDatabase() {
+        this.databaseCleanupUtility.truncateTablesAllTables();
+    }
+
+    @Test
+    void shouldNotRefreshIfOneDataset() {
+        DatasetModel dA = new DatasetModel("Ref_A", "AAAA", "abv", "desc");
+        datasetRepository.save(dA);
+        ConceptModel cA = new ConceptModel(dA.getDatasetId(), "c_A", "desc", "continuous", "\\Ref_A\\path\\");
+        ConceptModel cB = new ConceptModel(dA.getDatasetId(), "c_B", "desc", "continuous", "\\Ref_B\\path\\");
+        ConceptModel cC = new ConceptModel(dA.getDatasetId(), "c_C", "desc", "continuous", "\\Ref_C\\path\\");
+        conceptRepository.save(cA);
+        conceptRepository.save(cB);
+        conceptRepository.save(cC);
+
+        subject.refreshDatasetFacet();
+
+        Optional<FacetCategoryModel> category = facetCategoryRepository.findByName("dataset_id");
+        Assertions.assertFalse(category.isPresent());
+        List<String> actual = facetRepository.getAllFacetNames();
+        List<String> expected = List.of();
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void shouldDeleteAllIfCategoryExists() {
+        DatasetModel dA = new DatasetModel("Ref_A", "AAAA", "abv", "desc");
+        DatasetModel dB = new DatasetModel("Ref_B", "BBBB", "abv", "desc");
+        DatasetModel dC = new DatasetModel("Ref_C", "CCCC", "abv", "desc");
+        datasetRepository.save(dA);
+        datasetRepository.save(dB);
+        datasetRepository.save(dC);
+        ConceptModel cA = new ConceptModel(dA.getDatasetId(), "c_A", "desc", "continuous", "\\Ref_A\\path\\");
+        ConceptModel cB = new ConceptModel(dB.getDatasetId(), "c_B", "desc", "continuous", "\\Ref_B\\path\\");
+        ConceptModel cC = new ConceptModel(dC.getDatasetId(), "c_C", "desc", "continuous", "\\Ref_C\\path\\");
+        conceptRepository.save(cA);
+        conceptRepository.save(cB);
+        conceptRepository.save(cC);
+
+        subject.refreshDatasetFacet();
+
+        Optional<FacetCategoryModel> category = facetCategoryRepository.findByName("dataset_id");
+        Assertions.assertTrue(category.isPresent());
+        // there is a facet for each dataset
+        List<String> actual = facetRepository.getAllFacetNames();
+        List<String> expected = List.of("Ref_A", "Ref_B", "Ref_C");
+        Assertions.assertEquals(expected, actual);
+        // every concept is associated with a facet
+        List<Long> actualConcepts = facetConceptRepository.findAll().stream().map(FacetConceptModel::getConceptNodeId).toList();
+        List<Long> expectedConcepts = Stream.of(cA, cB, cC).map(ConceptModel::getConceptNodeId).toList();
+        Assertions.assertEquals(expectedConcepts, actualConcepts);
+    }
+}

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/facet/FacetConceptRepositoryTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/facet/FacetConceptRepositoryTest.java
@@ -1,0 +1,145 @@
+package edu.harvard.dbmi.avillach.dictionaryetl.facet;
+
+import edu.harvard.dbmi.avillach.dictionaryetl.Utility.DatabaseCleanupUtility;
+import edu.harvard.dbmi.avillach.dictionaryetl.concept.ConceptModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.concept.ConceptRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.dataset.DatasetModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.dataset.DatasetRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.facetcategory.FacetCategoryModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.facetcategory.FacetCategoryRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.List;
+import java.util.Optional;
+
+@Testcontainers
+@ActiveProfiles("test")
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class FacetConceptRepositoryTest {
+
+    @Autowired
+    private DatabaseCleanupUtility databaseCleanupUtility;
+
+    @Autowired
+    FacetRepository facetRepository;
+
+    @Autowired
+    FacetCategoryRepository facetCategoryRepository;
+
+    @Autowired
+    ConceptRepository conceptRepository;
+
+    @Autowired
+    DatasetRepository datasetRepository;
+
+    @Autowired
+    FacetConceptRepository subject;
+
+    @Container
+    static final PostgreSQLContainer<?> databaseContainer = new PostgreSQLContainer<>("postgres:16")
+        .withDatabaseName("testdb")
+        .withUsername("testuser")
+        .withPassword("testpass")
+        .withCopyFileToContainer(
+            MountableFile.forClasspathResource("schema.sql"),
+            "/docker-entrypoint-initdb.d/schema.sql"
+        );
+
+    @DynamicPropertySource
+    static void mySQLProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", databaseContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", databaseContainer::getUsername);
+        registry.add("spring.datasource.password", databaseContainer::getPassword);
+    }
+
+    @BeforeEach
+    void cleanDatabase() {
+        this.databaseCleanupUtility.truncateTablesAllTables();
+    }
+
+
+    @Test
+    void shouldDeleteForCategory() {
+        DatasetModel dataset = new DatasetModel("ref", "full", "abv", "desc");
+        datasetRepository.save(dataset);
+        FacetCategoryModel cat = new FacetCategoryModel("cat", "Cat", "category");
+        facetCategoryRepository.save(cat);
+        FacetModel facet = new FacetModel(cat.getFacetCategoryId(), "f", "F", "facet", null);
+        facetRepository.save(facet);
+        ConceptModel concept = new ConceptModel(dataset.getDatasetId(), "my_concept", "desc", "continuous", "\\my\\path\\");
+        conceptRepository.save(concept);
+        FacetConceptModel pair = new FacetConceptModel(facet.getFacetId(), concept.getConceptNodeId());
+        subject.save(pair);
+        Optional<List<FacetConceptModel>> forFacet = subject.findByFacetId(facet.getFacetId());
+        Assertions.assertTrue(forFacet.isPresent());
+        Assertions.assertEquals(1, forFacet.get().size());
+        Assertions.assertEquals(pair.getFacetConceptId(), forFacet.get().getFirst().getFacetConceptId());
+
+        subject.deleteAllForCategory(cat.getFacetCategoryId());
+
+        forFacet = subject.findByFacetId(facet.getFacetId());
+        Assertions.assertTrue(forFacet.isPresent());
+        Assertions.assertTrue(forFacet.get().isEmpty());
+    }
+
+    @Test
+    void shouldNotDeleteForOtherCategory() {
+        DatasetModel dataset = new DatasetModel("ref", "full", "abv", "desc");
+        datasetRepository.save(dataset);
+        FacetCategoryModel cat = new FacetCategoryModel("cat", "Cat", "category");
+        facetCategoryRepository.save(cat);
+        FacetModel facet = new FacetModel(cat.getFacetCategoryId(), "f", "F", "facet", null);
+        facetRepository.save(facet);
+        ConceptModel concept = new ConceptModel(dataset.getDatasetId(), "my_concept", "desc", "continuous", "\\my\\path\\");
+        conceptRepository.save(concept);
+        FacetConceptModel pair = new FacetConceptModel(facet.getFacetId(), concept.getConceptNodeId());
+        subject.save(pair);
+        Optional<List<FacetConceptModel>> forFacet = subject.findByFacetId(facet.getFacetId());
+        Assertions.assertTrue(forFacet.isPresent());
+        Assertions.assertEquals(1, forFacet.get().size());
+        Assertions.assertEquals(pair.getFacetConceptId(), forFacet.get().getFirst().getFacetConceptId());
+
+        subject.deleteAllForCategory(cat.getFacetCategoryId() + 1);
+
+        forFacet = subject.findByFacetId(facet.getFacetId());
+        Assertions.assertTrue(forFacet.isPresent());
+        Assertions.assertEquals(1, forFacet.get().size());
+    }
+
+    @Test
+    void shouldCreateFacetForEachDataset() {
+        DatasetModel dA = new DatasetModel("Ref_A", "AAAA", "abv", "desc");
+        DatasetModel dB = new DatasetModel("Ref_B", "BBBB", "abv", "desc");
+        DatasetModel dC = new DatasetModel("Ref_C", "CCCC", "abv", "desc");
+        datasetRepository.save(dA);
+        datasetRepository.save(dB);
+        datasetRepository.save(dC);
+        ConceptModel cA = new ConceptModel(dA.getDatasetId(), "c_A", "desc", "continuous", "\\Ref_A\\path\\");
+        ConceptModel cB = new ConceptModel(dA.getDatasetId(), "c_B", "desc", "continuous", "\\Ref_B\\path\\");
+        ConceptModel cC = new ConceptModel(dA.getDatasetId(), "c_C", "desc", "continuous", "\\Ref_C\\path\\");
+        conceptRepository.save(cA);
+        conceptRepository.save(cB);
+        conceptRepository.save(cC);
+
+        FacetCategoryModel cat = new FacetCategoryModel("dataset_id", "Datasets", "category");
+        facetCategoryRepository.save(cat);
+        facetRepository.createFacetForEachDatasetForCategory(cat.getFacetCategoryId());
+
+        subject.createDatasetPairForEachLeafConcept(cat.getFacetCategoryId());
+
+        Assertions.assertEquals(3, subject.findAll().size());
+    }
+}

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/facet/FacetRepositoryTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/facet/FacetRepositoryTest.java
@@ -1,0 +1,109 @@
+package edu.harvard.dbmi.avillach.dictionaryetl.facet;
+
+import edu.harvard.dbmi.avillach.dictionaryetl.Utility.DatabaseCleanupUtility;
+import edu.harvard.dbmi.avillach.dictionaryetl.concept.ConceptRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.dataset.DatasetModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.dataset.DatasetRepository;
+import edu.harvard.dbmi.avillach.dictionaryetl.facetcategory.FacetCategoryModel;
+import edu.harvard.dbmi.avillach.dictionaryetl.facetcategory.FacetCategoryRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.List;
+
+@Testcontainers
+@ActiveProfiles("test")
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class FacetRepositoryTest {
+
+    @Autowired
+    private DatabaseCleanupUtility databaseCleanupUtility;
+
+    @Autowired
+    FacetRepository subject;
+
+    @Autowired
+    FacetCategoryRepository facetCategoryRepository;
+
+    @Autowired
+    ConceptRepository conceptRepository;
+
+    @Autowired
+    DatasetRepository datasetRepository;
+
+    @Container
+    static final PostgreSQLContainer<?> databaseContainer = new PostgreSQLContainer<>("postgres:16")
+        .withDatabaseName("testdb")
+        .withUsername("testuser")
+        .withPassword("testpass")
+        .withCopyFileToContainer(
+            MountableFile.forClasspathResource("schema.sql"),
+            "/docker-entrypoint-initdb.d/schema.sql"
+        );
+
+    @DynamicPropertySource
+    static void mySQLProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", databaseContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", databaseContainer::getUsername);
+        registry.add("spring.datasource.password", databaseContainer::getPassword);
+    }
+
+    @BeforeEach
+    void cleanDatabase() {
+        this.databaseCleanupUtility.truncateTablesAllTables();
+    }
+
+    @Test
+    void shouldDeleteAllForCategory() {
+        FacetCategoryModel cat = new FacetCategoryModel("cat", "Cat", "category");
+        facetCategoryRepository.save(cat);
+        FacetModel facet = new FacetModel(cat.getFacetCategoryId(), "f", "F", "facet", null);
+        subject.save(facet);
+
+        Assertions.assertTrue(subject.findByName("f").isPresent());
+        subject.deleteAllForCategory(cat.getFacetCategoryId());
+        Assertions.assertTrue(subject.findByName("f").isEmpty());
+    }
+
+    @Test
+    void shouldNotDeleteAllForCategoryThatDNE() {
+        FacetCategoryModel cat = new FacetCategoryModel("cat", "Cat", "category");
+        facetCategoryRepository.save(cat);
+        FacetModel facet = new FacetModel(cat.getFacetCategoryId(), "f", "F", "facet", null);
+        subject.save(facet);
+
+        Assertions.assertTrue(subject.findByName("f").isPresent());
+        subject.deleteAllForCategory(0L);
+        Assertions.assertTrue(subject.findByName("f").isPresent());
+    }
+
+    @Test
+    void shouldCreateFacetForEachDatasetForCategory() {
+        DatasetModel dA = new DatasetModel("Ref_A", "AAAA", "abv", "desc");
+        DatasetModel dB = new DatasetModel("Ref_B", "BBBB", "abv", "desc");
+        DatasetModel dC = new DatasetModel("Ref_C", "CCCC", "abv", "desc");
+        datasetRepository.save(dA);
+        datasetRepository.save(dB);
+        datasetRepository.save(dC);
+        FacetCategoryModel cat = new FacetCategoryModel("dataset_id", "Datasets", "category");
+        facetCategoryRepository.save(cat);
+
+        subject.createFacetForEachDatasetForCategory(cat.getFacetCategoryId());
+        List<String> actual = subject.getAllFacetNames();
+
+        List<String> expected = List.of("Ref_A", "Ref_B", "Ref_C");
+        Assertions.assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
- DatasetFacetRefreshService refreshes the dataset facet when a study is added
- Added logic to various Repos to support deleting and re-adding that facet, its category, and its facet/concept pairs