### PR TITLE
feat: Add timestamp support in ConceptMetadataModelMapper

### DIFF
--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaFlattener.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaFlattener.java
@@ -53,6 +53,7 @@ public class ColumnMetaFlattener {
             }
         }
 
+        boolean isTimestamp = columnMetas.stream().anyMatch(ColumnMeta::timestamp);
         return new ColumnMeta(
                 columnMetas.getFirst().name(),
                 null,
@@ -64,7 +65,8 @@ public class ColumnMetaFlattener {
                 null,
                 null,
                 null,
-                null
+                null,
+                isTimestamp
         );
     }
 
@@ -72,6 +74,7 @@ public class ColumnMetaFlattener {
         Set<String> setOfVals = new HashSet<>();
         columnMetas.forEach(columnMeta -> setOfVals.addAll(columnMeta.categoryValues()));
 
+        boolean isTimestamp = columnMetas.stream().anyMatch(ColumnMeta::timestamp);
         List<String> values = new ArrayList<>(setOfVals);
         return new ColumnMeta(
                 columnMetas.getFirst().name(),
@@ -84,7 +87,8 @@ public class ColumnMetaFlattener {
                 null,
                 null,
                 null,
-                null
+                null,
+                isTimestamp
         );
     }
 

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaMapper.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaMapper.java
@@ -31,6 +31,7 @@ public class ColumnMetaMapper {
 
         String col9 = getOptional(cells, 9);
         String col10 = getOptional(cells, 10);
+        boolean isTimestamp = "true".equalsIgnoreCase(getOptional(cells, 11));
 
         return new ColumnMeta(
                 conceptPath,
@@ -43,7 +44,8 @@ public class ColumnMetaMapper {
                 cells[7],
                 cells[8],
                 col9,
-                col10
+                col10,
+                isTimestamp
         );
     }
 

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaTreeBuilder.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaTreeBuilder.java
@@ -71,7 +71,7 @@ public class ColumnMetaTreeBuilder {
 
             if (i == node.length - 1) {
                 currentNode.getConceptModel().setConceptType(ConceptTypes.conceptTypeFromColumnMeta(columnMeta));
-                currentNode.setConceptMetadataModel(conceptMetadataModelMapper.fromColumnMeta(columnMeta));
+                currentNode.setConceptMetadataModels(conceptMetadataModelMapper.fromColumnMeta(columnMeta));
             }
 
             parent = currentNode;

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaTreePersister.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaTreePersister.java
@@ -134,10 +134,10 @@ public class ColumnMetaTreePersister {
             Executor executor
     ) {
         for (ConceptNode node : batchNodes) {
-            ConceptMetadataModel conceptMetadataModel = node.getConceptMetadataModel();
-            if (conceptMetadataModel != null) {
-                conceptMetadataModel.setConceptNodeId(node.getConceptModel().getConceptNodeId());
-                pendingMetadata.add(conceptMetadataModel);
+            List<ConceptMetadataModel> models = node.getConceptMetadataModels();
+            for (ConceptMetadataModel model : models) {
+                model.setConceptNodeId(node.getConceptModel().getConceptNodeId());
+                pendingMetadata.add(model);
 
                 if (pendingMetadata.size() >= BATCH_SIZE) {
                     metadataFutures.add(saveMetadataBatchAsync(List.copyOf(pendingMetadata), executor));

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ConceptMetadataModelMapper.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ConceptMetadataModelMapper.java
@@ -6,6 +6,7 @@ import edu.harvard.dbmi.avillach.dictionaryetl.concept.ConceptMetadataModel;
 import edu.harvard.dbmi.avillach.dictionaryetl.loading.model.ColumnMeta;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -17,7 +18,7 @@ public class ConceptMetadataModelMapper {
         this.columnMetaUtility = columnMetaUtility;
     }
 
-    public ConceptMetadataModel fromColumnMeta(ColumnMeta columnMeta) {
+    public List<ConceptMetadataModel> fromColumnMeta(ColumnMeta columnMeta) {
         try {
             List<String> values = columnMeta.categoryValues();
             if (!columnMeta.categorical()) {
@@ -25,7 +26,14 @@ public class ConceptMetadataModelMapper {
             }
 
             String valuesJson = this.columnMetaUtility.listToJson(values);
-            return new ConceptMetadataModel("values", valuesJson);
+            List<ConceptMetadataModel> result = new ArrayList<>();
+            result.add(new ConceptMetadataModel("values", valuesJson));
+
+            if (columnMeta.timestamp()) {
+                result.add(new ConceptMetadataModel("is_timestamp", "true"));
+            }
+
+            return result;
 
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/model/ColumnMeta.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/model/ColumnMeta.java
@@ -13,6 +13,7 @@ public record ColumnMeta(
     String allObservationsOffset,
     String allObservationsLength,
     String observationCount,
-    String patientCount
+    String patientCount,
+    boolean timestamp
 ) {
 }

--- a/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/model/ConceptNode.java
+++ b/src/main/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/model/ConceptNode.java
@@ -3,6 +3,8 @@ package edu.harvard.dbmi.avillach.dictionaryetl.loading.model;
 import edu.harvard.dbmi.avillach.dictionaryetl.concept.ConceptMetadataModel;
 import edu.harvard.dbmi.avillach.dictionaryetl.concept.ConceptModel;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -11,7 +13,7 @@ public class ConceptNode {
     private String datasetRef;
     private String conceptPath;
     private ConceptModel conceptModel;
-    private ConceptMetadataModel conceptMetadataModel;
+    private List<ConceptMetadataModel> conceptMetadataModels = new ArrayList<>();
 
     private ConceptNode parent;
     private final ConcurrentMap<String, ConceptNode> children = new ConcurrentHashMap<>();
@@ -73,12 +75,12 @@ public class ConceptNode {
         this.datasetRef = datasetRef;
     }
 
-    public ConceptMetadataModel getConceptMetadataModel() {
-        return conceptMetadataModel;
+    public List<ConceptMetadataModel> getConceptMetadataModels() {
+        return conceptMetadataModels;
     }
 
-    public void setConceptMetadataModel(ConceptMetadataModel conceptMetadataModel) {
-        this.conceptMetadataModel = conceptMetadataModel;
+    public void setConceptMetadataModels(List<ConceptMetadataModel> conceptMetadataModels) {
+        this.conceptMetadataModels = conceptMetadataModels;
     }
 
     @Override
@@ -87,7 +89,7 @@ public class ConceptNode {
                "datasetRef='" + datasetRef + '\'' +
                ", conceptPath='" + conceptPath + '\'' +
                ", conceptModel=" + conceptModel +
-               ", conceptMeta=" + conceptMetadataModel +
+               ", conceptMeta=" + conceptMetadataModels +
                ", parent=" + parent +
                ", children=" + children +
                '}';

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaMapperTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ColumnMetaMapperTest.java
@@ -39,7 +39,7 @@ class ColumnMetaMapperTest {
 
                 // dates are parsed as category values
                 assertFalse(cmOpt.categoryValues().isEmpty());
-                assertTrue(cmOpt.categoryValues().get(0).matches("\\d{4}-\\d{2}-\\d{2}"));
+                assertTrue(cmOpt.categoryValues().getFirst().matches("\\d{4}-\\d{2}-\\d{2}"));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -137,6 +137,22 @@ class ColumnMetaMapperTest {
     void shouldParseGenomicConceptPath_ofLengthTwo() throws IOException {
         ColumnMeta columnMeta = this.columnMetaMapper.mapCSVRowToColumnMeta(csvParser.parseLine("\\open_access-1000Genomes\\GENOMES ON GRCH381000\\,5,0,true,FALSE,null,null,1569879,1735060,4978,4978"));
         assertEquals("\\open_access-1000Genomes\\GENOMES ON GRCH381000\\", columnMeta.name());
+    }
+
+    @Test
+    void shouldParseTimestampTrue_whenColumn11IsTrue() throws IOException {
+        String csvRow = "\\study\\variable\\,8,0,false,,0.0,85.0,380670,761347,9999,9999,true";
+        ColumnMeta columnMeta = columnMetaMapper.mapCSVRowToColumnMeta(csvParser.parseLine(csvRow));
+        assertNotNull(columnMeta);
+        assertTrue(columnMeta.timestamp());
+    }
+
+    @Test
+    void shouldParseTimestampFalse_whenColumn11IsAbsent() throws IOException {
+        String csvRow = "\\study\\variable\\,8,0,false,,0.0,85.0,380670,761347,9999,9999";
+        ColumnMeta columnMeta = columnMetaMapper.mapCSVRowToColumnMeta(csvParser.parseLine(csvRow));
+        assertNotNull(columnMeta);
+        assertFalse(columnMeta.timestamp());
     }
 
 }

--- a/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ConceptMetadataModelMapperTest.java
+++ b/src/test/java/edu/harvard/dbmi/avillach/dictionaryetl/loading/ConceptMetadataModelMapperTest.java
@@ -30,11 +30,13 @@ class ConceptMetadataModelMapperTest {
                null,
                 null,
                null,
-                null
+                null,
+                false
         );
-        ConceptMetadataModel conceptMetadataModel = this.conceptMetadataModelMapper.fromColumnMeta(columnMeta);
-        assertNotNull(conceptMetadataModel);
-        assertEquals("[\"10.0\",\"20.0\"]", conceptMetadataModel.getValue());
+        List<ConceptMetadataModel> result = this.conceptMetadataModelMapper.fromColumnMeta(columnMeta);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("[\"10.0\",\"20.0\"]", result.getFirst().getValue());
     }
 
     @Test
@@ -50,10 +52,58 @@ class ConceptMetadataModelMapperTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                false
         );
-        ConceptMetadataModel conceptMetadataModel = this.conceptMetadataModelMapper.fromColumnMeta(columnMeta);
-        assertNotNull(conceptMetadataModel);
-        assertEquals("[\"up\",\"down\",\"left\",\"right\"]", conceptMetadataModel.getValue());
+        List<ConceptMetadataModel> result = this.conceptMetadataModelMapper.fromColumnMeta(columnMeta);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("[\"up\",\"down\",\"left\",\"right\"]", result.getFirst().getValue());
+    }
+
+    @Test
+    void shouldIncludeIsTimestamp_whenTimestampIsTrue() {
+        ColumnMeta columnMeta = new ColumnMeta(
+                "test",
+                "0",
+                "1",
+                true,
+                List.of("2024-01-01", "2024-01-02"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                true
+        );
+        List<ConceptMetadataModel> result = this.conceptMetadataModelMapper.fromColumnMeta(columnMeta);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("values", result.get(0).getKey());
+        assertEquals("is_timestamp", result.get(1).getKey());
+        assertEquals("true", result.get(1).getValue());
+    }
+
+    @Test
+    void shouldNotIncludeIsTimestamp_whenTimestampIsFalse() {
+        ColumnMeta columnMeta = new ColumnMeta(
+                "test",
+                "0",
+                "1",
+                true,
+                List.of("a", "b"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false
+        );
+        List<ConceptMetadataModel> result = this.conceptMetadataModelMapper.fromColumnMeta(columnMeta);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertTrue(result.stream().noneMatch(m -> "is_timestamp".equals(m.getKey())));
     }
 }


### PR DESCRIPTION
- Update `ConceptMetadataModelMapper` to include `is_timestamp` metadata when applicable.
- Make `fromColumnMeta` return a list of `ConceptMetadataModel` instances.
- Modify related classes to handle multiple metadata models.
- Update tests for `ConceptMetadataModelMapper` and `ColumnMetaMapper` to validate new behavior.
- Extend `ColumnMeta` class with a `timestamp` field for better handling.
- Refactor `ConceptNode` to support multiple metadata models.